### PR TITLE
feat: uplift @side-quest/last-30-days v0.1.1

### DIFF
--- a/.changeset/uplift-last-30-days.md
+++ b/.changeset/uplift-last-30-days.md
@@ -1,0 +1,8 @@
+---
+"@side-quest/community-intel-cache": minor
+---
+
+Support @side-quest/last-30-days v0.1.1 --refresh flag and metadata fields
+
+- Pass `--refresh` to last-30-days when `--force` is used, bypassing its internal per-source cache
+- Add optional v0.1.1 metadata fields to `Last30DaysReport` type (days, generated_at, mode, model info, best_practices, prompt_pack, context_snippet_md)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -261,6 +261,7 @@ async function executeRefresh(options: CliOptions): Promise<void> {
 		diagnostics,
 		options.verbose,
 		days,
+		options.force,
 	)
 
 	// Count successful queries (returned data)

--- a/src/gather.ts
+++ b/src/gather.ts
@@ -60,6 +60,7 @@ async function runQuery(
 	diagnostics: QueryError[],
 	verbose: boolean,
 	days: number = CONFIG_DEFAULTS.days,
+	forceRefresh = false,
 ): Promise<Last30DaysReport | null> {
 	const bunx = resolveBunx()
 	const cmd = [
@@ -71,6 +72,10 @@ async function runQuery(
 		'--quick',
 		`--days=${days}`,
 	]
+
+	if (forceRefresh) {
+		cmd.push('--refresh')
+	}
 
 	if (verbose) {
 		console.error(`[gather] querying: ${topic}`)
@@ -138,8 +143,11 @@ export async function gatherTopics(
 	diagnostics: QueryError[],
 	verbose = false,
 	days: number = CONFIG_DEFAULTS.days,
+	forceRefresh = false,
 ): Promise<Array<Last30DaysReport | null>> {
 	return Promise.all(
-		topics.map((topic) => runQuery(topic, diagnostics, verbose, days)),
+		topics.map((topic) =>
+			runQuery(topic, diagnostics, verbose, days, forceRefresh),
+		),
 	)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,22 @@ export interface Last30DaysReport {
 		why_relevant: string
 		score: number
 	}>
+	/** Lookback window used for this query. */
+	days?: number
+	/** ISO timestamp when this report was generated. */
+	generated_at?: string
+	/** Source mode used (e.g. "both", "reddit", "x"). */
+	mode?: string
+	/** OpenAI model used for Reddit synthesis. */
+	openai_model_used?: string
+	/** xAI model used for X synthesis. */
+	xai_model_used?: string
+	/** Best practices extracted from research. */
+	best_practices?: string[]
+	/** Prompt snippets derived from research. */
+	prompt_pack?: string[]
+	/** Pre-formatted markdown context snippet. */
+	context_snippet_md?: string
 }
 
 /** Status reported on exit via JSON to stdout. */


### PR DESCRIPTION
## Summary

- Add support for `@side-quest/last-30-days` v0.1.1 `--refresh` flag to bypass per-source cache
- Add optional v0.1.1 metadata fields to `Last30DaysReport` type

## Changes

### 1. `src/types.ts` - Type updates
- Added 8 optional metadata fields to `Last30DaysReport` interface:
  - `days` - lookback window used
  - `generated_at` - ISO timestamp
  - `mode` - source mode (e.g. "both", "reddit", "x")
  - `openai_model_used` - Reddit synthesis model
  - `xai_model_used` - X synthesis model
  - `best_practices` - extracted best practices
  - `prompt_pack` - derived prompt snippets
  - `context_snippet_md` - pre-formatted markdown snippet

### 2. `src/gather.ts` - Force refresh support
- Added `forceRefresh` parameter to `runQuery()` and `gatherTopics()`
- Conditionally push `--refresh` to command array when true

### 3. `src/cli.ts` - CLI integration
- Thread `options.force` to `gatherTopics()` so `--force` bypasses both local staleness check and last-30-days' internal cache

## Why this matters

Previously `--force` only skipped the local `isCacheFresh()` check but still hit last-30-days' per-source cache. Now `--refresh` propagates through, enabling true end-to-end force refresh.

## Test plan

- [x] All 72 tests pass
- [x] Lint clean (biome)
- [x] Typecheck clean (tsc)
- [x] Build clean (bunup)
- [x] Changeset included for minor version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--refresh` flag support to bypass internal cache when forcing data refresh in the last-30-days tool.
  * Extended reports with enhanced metadata including generation timestamps, operation mode, model information, best practices, and context snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->